### PR TITLE
Use GSAP timeline for TipFrom5 animation

### DIFF
--- a/src/components/TipAlertAnimations/Default.tsx
+++ b/src/components/TipAlertAnimations/Default.tsx
@@ -78,6 +78,10 @@ const Default: React.FC<DefaultProps> = ({
     startPlayback();
   }, [donate.amount, donate.commission, donate.id, donate.message, donate.nickname, out, sound?.url, sound?.volume, speech, withCommission]);
 
+  useEffect(() => {
+    if (out) onAnimationEnd();
+  }, [out, onAnimationEnd]);
+
 
   const amount = withCommission
     ? donate.amount - donate.commission


### PR DESCRIPTION
## Summary
- replace animate.css in TipFrom5 with GSAP timeline and refs
- trigger completion via timeline onComplete callback
- ensure Default animation triggers onAnimationEnd to satisfy lint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7f926d5b88321b8fb9b48edfa95ad