### PR TITLE
Replace animate.css tip animations with GSAP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "kaaajka-website",
       "version": "0.1.0",
       "dependencies": {
-        "animate.css": "^4.1.1",
         "gsap": "^3.13.0",
         "howler": "^2.2.4",
         "next": "15.3.5",
@@ -1937,12 +1936,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
-    },
-    "node_modules/animate.css": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/animate.css/-/animate.css-4.1.1.tgz",
-      "integrity": "sha512-+mRmCTv6SbCmtYJCN4faJMNFVNN5EuCTTprDTAo7YzIGji2KADmakjVA3+8mVDkZ2Bf09vayB35lSQIex2+QaQ==",
-      "license": "MIT"
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "animate.css": "^4.1.1",
     "gsap": "^3.13.0",
     "howler": "^2.2.4",
     "next": "15.3.5",

--- a/src/components/TipAlertAnimations/Default.tsx
+++ b/src/components/TipAlertAnimations/Default.tsx
@@ -3,9 +3,9 @@
 'use client';
 import React, { useEffect, useState } from 'react';
 import { DonatePayload, SoundConfig, SpeechConfig } from '@/types';
-import 'animate.css';
 import { AudioManager } from '@/lib/AudioManager';
 import Image from 'next/image';
+import GsapTipAnimation from './GsapTipAnimation';
 
 interface DefaultProps {
   donate: DonatePayload;
@@ -90,28 +90,30 @@ const Default: React.FC<DefaultProps> = ({
 
   return (
     <div className="wrapper">
-      <div className="donate">
-        {!!images.length && (
-          <Image
-            src="https://tipply.pl/upload/media/user/0006/25/47168b05ea7a9cfd89f906886b7878ab26d74423.gif"
-            alt="Tip"
-            width={52}
-            height={52}
-            className="image"
-            unoptimized
-          />
-        )}
+      <GsapTipAnimation out={out} onAnimationEnd={onAnimationEnd}>
+        <div className="donate">
+          {!!images.length && (
+            <Image
+              src="https://tipply.pl/upload/media/user/0006/25/47168b05ea7a9cfd89f906886b7878ab26d74423.gif"
+              alt="Tip"
+              width={52}
+              height={52}
+              className="image"
+              unoptimized
+            />
+          )}
 
-        <div className={'user animate__animated animate__pulse'}>
-          <span className="nickname">{donate.nickname} </span>
-          wrzuca
-          <span className="amount"> {formatted}</span>
+          <div className="user">
+            <span className="nickname">{donate.nickname} </span>
+            wrzuca
+            <span className="amount"> {formatted}</span>
+          </div>
+
+          <div className="message">{donate.message}</div>
         </div>
-
-        <div className="message">{donate.message}</div>
-      </div>
+      </GsapTipAnimation>
     </div>
-  );  
+  );
 };
 
 export default Default;

--- a/src/components/TipAlertAnimations/GsapTipAnimation.tsx
+++ b/src/components/TipAlertAnimations/GsapTipAnimation.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import React, { useEffect, useRef } from 'react';
+import { gsap } from 'gsap';
+
+interface GsapTipAnimationProps {
+  out: boolean;
+  onAnimationEnd: () => void;
+  children: React.ReactNode;
+}
+
+const GsapTipAnimation: React.FC<GsapTipAnimationProps> = ({
+  out,
+  onAnimationEnd,
+  children,
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    if (!out) {
+      gsap.fromTo(
+        el,
+        { autoAlpha: 0, y: -100 },
+        { autoAlpha: 1, y: 0, duration: 0.5, ease: 'power3.out' }
+      );
+    } else {
+      gsap.to(el, {
+        autoAlpha: 0,
+        y: -100,
+        duration: 0.5,
+        ease: 'power3.in',
+        onComplete: onAnimationEnd,
+      });
+    }
+  }, [out, onAnimationEnd]);
+
+  return <div ref={ref}>{children}</div>;
+};
+
+export default GsapTipAnimation;
+

--- a/src/components/TipAlertAnimations/TipFrom100.tsx
+++ b/src/components/TipAlertAnimations/TipFrom100.tsx
@@ -3,9 +3,9 @@
 'use client';
 import React, { useEffect, useState, useRef } from 'react';
 import { DonatePayload, SoundConfig, SpeechConfig } from '@/types';
-import 'animate.css';
 import { AudioManager } from '@/lib/AudioManager';
 import Image from 'next/image';
+import GsapTipAnimation from './GsapTipAnimation';
 
 interface TipFrom100Props {
   donate: DonatePayload;
@@ -107,39 +107,33 @@ const TipFrom100: React.FC<TipFrom100Props> = ({
         ))}
       </div>
 
-      <div
-        className={
-          'donate fifth animate__animated ' +
-          (out ? 'animate__fadeOutUp' : 'animate__fadeInDownBig')
-        }
-        onAnimationEnd={() => {
-          if (out) onAnimationEnd();
-        }}
-      >
-        {!!images.length && (
-          <Image
-            src={images[0]}
-            alt="Tip"
-            width={52}
-            height={52}
-            className="image"
-            unoptimized
-          />
-        )}
+      <GsapTipAnimation out={out} onAnimationEnd={onAnimationEnd}>
+        <div className="donate fifth">
+          {!!images.length && (
+            <Image
+              src={images[0]}
+              alt="Tip"
+              width={52}
+              height={52}
+              className="image"
+              unoptimized
+            />
+          )}
 
-        <div className="user animate__animated animate__pulse">
-          <div>
-            Ale, że
-            <span className="nickname"> {donate.nickname} </span>
-            wpłacił
+          <div className="user">
+            <div>
+              Ale, że
+              <span className="nickname"> {donate.nickname} </span>
+              wpłacił
+            </div>
+            <div>
+              <span className="amount"> {formatted}?? </span> OMG!
+            </div>
           </div>
-          <div>
-            <span className="amount"> {formatted}?? </span> OMG!
-          </div>
+
+          <div className="text">{donate.message}</div>
         </div>
-
-        <div className="text">{donate.message}</div>
-      </div>
+      </GsapTipAnimation>
     </div>
   );
 };

--- a/src/components/TipAlertAnimations/TipFrom150.tsx
+++ b/src/components/TipAlertAnimations/TipFrom150.tsx
@@ -3,9 +3,9 @@
 'use client';
 import React, { useEffect, useState, useRef } from 'react';
 import { DonatePayload, SoundConfig, SpeechConfig } from '@/types';
-import 'animate.css';
 import { AudioManager } from '@/lib/AudioManager';
 import Image from 'next/image';
+import GsapTipAnimation from './GsapTipAnimation';
 
 interface TipFrom150Props {
   donate: DonatePayload;
@@ -92,54 +92,41 @@ const TipFrom150: React.FC<TipFrom150Props> = ({
         ))}
       </div>
 
-      <div
-        className={
-          'donate sixth animate__animated ' + (out ? 'animate__fadeOutUp' : '')
-        }
-        onAnimationEnd={() => {
-          if (out) onAnimationEnd();
-        }}
-      >
-        {!showTogether && (
-          <>
-            <div className="halo h1 animate__animated animate__fadeInDownBig">
-              !!! HALO !!!
-            </div>
-            <div className="halo h2 animate__animated animate__fadeInDownBig">
-              !!! HALO !!!
-            </div>
-          </>
-        )}
-        {showTogether && (
-          <div className="haloTogether animate__animated animate__flash">
-            !!! HALO HALO !!!
+      <GsapTipAnimation out={out} onAnimationEnd={onAnimationEnd}>
+        <div className="donate sixth">
+          {!showTogether && (
+            <>
+              <div className="halo h1">!!! HALO !!!</div>
+              <div className="halo h2">!!! HALO !!!</div>
+            </>
+          )}
+          {showTogether && (
+            <div className="haloTogether">!!! HALO HALO !!!</div>
+          )}
+
+          {!!images.length && (
+            <Image
+              src={images[0]}
+              alt="Tip"
+              width={52}
+              height={52}
+              className="image"
+              unoptimized
+            />
+          )}
+
+          <div className="user">
+            <span className="lala">
+              <span className="nickname"> {donate.nickname} </span>
+              wleciał/a za
+              <span className="amount"> {formatted} </span>
+              Co jest !?
+            </span>
           </div>
-        )}
 
-        {!!images.length && (
-          <Image
-            src={images[0]}
-            alt="Tip"
-            width={52}
-            height={52}
-            className="image animate__animated animate__fadeInRightBig"
-            unoptimized
-          />
-        )}
-
-        <div className="user animate__animated animate__fadeInUpBig">
-          <span className="lala animate__animated animate__pulse">
-            <span className="nickname"> {donate.nickname} </span>
-            wleciał/a za
-            <span className="amount"> {formatted} </span>
-            Co jest !?
-          </span>
+          <div className="text">{donate.message}</div>
         </div>
-
-        <div className="text animate__animated animate__fadeInUpBig">
-          {donate.message}
-        </div>
-      </div>
+      </GsapTipAnimation>
     </div>
   );
 };

--- a/src/components/TipAlertAnimations/TipFrom25.tsx
+++ b/src/components/TipAlertAnimations/TipFrom25.tsx
@@ -3,9 +3,9 @@
 'use client';
 import React, { useEffect, useState, useRef } from 'react';
 import { DonatePayload, SoundConfig, SpeechConfig } from '@/types';
-import 'animate.css';
 import { AudioManager } from '@/lib/AudioManager';
 import Image from 'next/image';
+import GsapTipAnimation from './GsapTipAnimation';
 
 interface TipFrom25Props {
   donate: DonatePayload;
@@ -81,33 +81,27 @@ const TipFrom25: React.FC<TipFrom25Props> = ({
 
   return (
     <div className="donateHolder">
-      <div
-        className={
-          'donate third animate__animated ' +
-          (out ? 'animate__fadeOutUp' : 'animate__fadeInDownBig')
-        }
-        onAnimationEnd={() => {
-          if (out) onAnimationEnd();
-        }}
-      >
-        {!!images.length && (
-          <Image
-            src={images[0]}
-            alt="Tip"
-            width={52}
-            height={52}
-            className="image"
-            unoptimized
-          />
-        )}
+      <GsapTipAnimation out={out} onAnimationEnd={onAnimationEnd}>
+        <div className="donate third">
+          {!!images.length && (
+            <Image
+              src={images[0]}
+              alt="Tip"
+              width={52}
+              height={52}
+              className="image"
+              unoptimized
+            />
+          )}
 
-        <div className="user animate__animated animate__pulse">
-          OMG <span className="nickname">{donate.nickname}</span> dzieki
-          <span className="amount"> {formatted}</span>!
+          <div className="user">
+            OMG <span className="nickname">{donate.nickname}</span> dzieki
+            <span className="amount"> {formatted}</span>!
+          </div>
+
+          <div className="text">{donate.message}</div>
         </div>
-
-        <div className="text">{donate.message}</div>
-      </div>
+      </GsapTipAnimation>
     </div>
   );
 };

--- a/src/components/TipAlertAnimations/TipFrom300.tsx
+++ b/src/components/TipAlertAnimations/TipFrom300.tsx
@@ -3,9 +3,9 @@
 'use client';
 import React, { useEffect, useState } from 'react';
 import { DonatePayload, SoundConfig, SpeechConfig } from '@/types';
-import 'animate.css';
 import { AudioManager } from '@/lib/AudioManager';
 import Image from 'next/image';
+import GsapTipAnimation from './GsapTipAnimation';
 
 interface TipFrom300Props {
   donate: DonatePayload;
@@ -88,77 +88,56 @@ const TipFrom300: React.FC<TipFrom300Props> = ({
 
   return (
     <div className="donateHolder">
-      <div
-        className={'animate__animated ' + (out ? 'animate__fadeOutUp' : '')}
-        onAnimationEnd={() => {
-          if (out) onAnimationEnd();
-        }}
-      >
-        <div className="moneyRain">
-          {[...Array(150)].map((_, i) => (
-            <i className="rain" key={`rain_${i}`} />
-          ))}
-        </div>
-
-        <div
-          className={
-            'haloFloats animate__animated ' + (out ? 'animate__fadeOutUp' : '')
-          }
-        >
-          {[...Array(30)].map((_, i) => (
-            <strong className="halo" key={`haloFloat_${i}`}>
-              HALO
-            </strong>
-          ))}
-        </div>
-
-        <div
-          className={
-            'donate seventh animate__animated ' +
-            (out ? 'animate__fadeOutUp' : '')
-          }
-        >
-          <div className="coZaPojeb animate__animated animate__flash">
-            <span className="co animate__animated animate__fadeInDownBig">
-              !!! CO
-            </span>
-            <span className="za animate__animated animate__fadeInDownBig">
-              {' '}
-              ZA{' '}
-            </span>
-            <span className="pojeb animate__animated animate__fadeInDownBig">
-              POJEB !!!
-            </span>
+      <GsapTipAnimation out={out} onAnimationEnd={onAnimationEnd}>
+        <>
+          <div className="moneyRain">
+            {[...Array(150)].map((_, i) => (
+              <i className="rain" key={`rain_${i}`} />
+            ))}
           </div>
 
-          {!!images.length && (
-            <Image
-              src={images[0]}
-              alt="Tip"
-              width={52}
-              height={52}
-              className="image animate__animated animate__fadeInRightBig"
-              unoptimized
-            />
-          )}
-
-          <div className="user animate__animated animate__fadeInUpBig">
-            <span className="donateInfo animate__animated animate__pulse">
-              <span className="nickname"> {donate.nickname} </span>
-              <br />
-              <span className="wtf">pierdolnął/ęła</span>
-              <br />
-              <span className="wtf">!! WTF !!</span>
-              <span className="amount"> {formatted} </span>
-              <span className="wtf">!! WTF !!</span>
-            </span>
+          <div className="haloFloats">
+            {[...Array(30)].map((_, i) => (
+              <strong className="halo" key={`haloFloat_${i}`}>
+                HALO
+              </strong>
+            ))}
           </div>
 
-          <div className="text animate__animated animate__fadeInUpBig">
-            {donate.message}
+          <div className="donate seventh">
+            <div className="coZaPojeb">
+              <span className="co">!!! CO</span>
+              <span className="za"> ZA </span>
+              <span className="pojeb"> POJEB !!!</span>
+            </div>
+
+            {!!images.length && (
+              <Image
+                src={images[0]}
+                alt="Tip"
+                width={52}
+                height={52}
+                className="image"
+                unoptimized
+              />
+            )}
+
+            <div className="user">
+              <span className="donateInfo">
+                <span className="nickname"> {donate.nickname} </span>
+                <br />
+                <span className="wtf">pierdolnął/ęła</span>
+                <br />
+                <span className="wtf">!! WTF !!</span>
+                <span className="amount"> {formatted} </span>
+                <span className="wtf">!! WTF !!</span>
+              </span>
+            </div>
+
+            <div className="text">{donate.message}</div>
           </div>
-        </div>
-      </div>
+        </>
+      </GsapTipAnimation>
     </div>
   );
 };

--- a/src/components/TipAlertAnimations/TipFrom5.tsx
+++ b/src/components/TipAlertAnimations/TipFrom5.tsx
@@ -3,9 +3,9 @@
 'use client';
 import React, { useEffect, useState } from 'react';
 import { DonatePayload, SoundConfig, SpeechConfig } from '@/types';
-import 'animate.css';
 import { AudioManager } from '@/lib/AudioManager';
 import Image from 'next/image';
+import GsapTipAnimation from './GsapTipAnimation';
 
 interface TipFrom5Props {
   donate: DonatePayload;
@@ -90,36 +90,30 @@ const TipFrom5: React.FC<TipFrom5Props> = ({
 
   return (
     <div className="donateHolder">
-      <div
-        className={
-          'donate first animate__animated ' +
-          (out ? 'animate__fadeOutUp' : 'animate__fadeInDownBig')
-        }
-        onAnimationEnd={() => {
-          if (out) onAnimationEnd();
-        }}
-      >
-        {!!images.length && (
-          <Image
-            src={images[0]}
-            alt="Tip"
-            width={52}
-            height={52}
-            className="image"
-            unoptimized
-          />
-        )}
+      <GsapTipAnimation out={out} onAnimationEnd={onAnimationEnd}>
+        <div className="donate first">
+          {!!images.length && (
+            <Image
+              src={images[0]}
+              alt="Tip"
+              width={52}
+              height={52}
+              className="image"
+              unoptimized
+            />
+          )}
 
-        <div className={'user animate__animated animate__pulse'}>
-          <span className="nickname">{donate.nickname} </span>
-          wrzuca
-          <span className="amount"> {formatted}</span>
+          <div className="user">
+            <span className="nickname">{donate.nickname} </span>
+            wrzuca
+            <span className="amount"> {formatted}</span>
+          </div>
+
+          <div className="text">{donate.message}</div>
         </div>
-
-        <div className="text">{donate.message}</div>
-      </div>
+      </GsapTipAnimation>
     </div>
-  );  
+  );
 };
 
 export default TipFrom5;

--- a/src/components/TipAlertAnimations/TipFrom50.tsx
+++ b/src/components/TipAlertAnimations/TipFrom50.tsx
@@ -3,9 +3,9 @@
 'use client';
 import React, { useEffect, useState, useRef } from 'react';
 import { DonatePayload, SoundConfig, SpeechConfig } from '@/types';
-import 'animate.css';
 import { AudioManager } from '@/lib/AudioManager';
 import Image from 'next/image';
+import GsapTipAnimation from './GsapTipAnimation';
 
 interface TipFrom50Props {
   donate: DonatePayload;
@@ -80,36 +80,30 @@ const TipFrom50: React.FC<TipFrom50Props> = ({
 
   return (
     <div className="donateHolder">
-      <div
-        className={
-          'donate fourth animate__animated ' +
-          (out ? 'animate__fadeOutUp' : 'animate__fadeInDownBig')
-        }
-        onAnimationEnd={() => {
-          if (out) onAnimationEnd();
-        }}
-      >
-        {!!images.length && (
-          <Image
-            src={images[0]}
-            alt="Tip"
-            width={52}
-            height={52}
-            className="image"
-            unoptimized
-          />
-        )}
+      <GsapTipAnimation out={out} onAnimationEnd={onAnimationEnd}>
+        <div className="donate fourth">
+          {!!images.length && (
+            <Image
+              src={images[0]}
+              alt="Tip"
+              width={52}
+              height={52}
+              className="image"
+              unoptimized
+            />
+          )}
 
-        <div className="user animate__animated animate__pulse">
-          WOWOW!!
-          <span className="nickname"> {donate.nickname} </span>
-          daje
-          <span className="amount"> {formatted} </span>
-          !! TAK O!
+          <div className="user">
+            WOWOW!!
+            <span className="nickname"> {donate.nickname} </span>
+            daje
+            <span className="amount"> {formatted} </span>
+            !! TAK O!
+          </div>
+
+          <div className="text">{donate.message}</div>
         </div>
-
-        <div className="text">{donate.message}</div>
-      </div>
+      </GsapTipAnimation>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add reusable `GsapTipAnimation` wrapper with GSAP fade in/out
- refactor tip components to use `GsapTipAnimation` and drop animate.css classes
- remove `animate.css` dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7f925602883218ee43ec11db1e1ec