### PR TITLE
Ensure GSAP animations revert on unmount

### DIFF
--- a/src/components/TipAlertAnimations/Default.tsx
+++ b/src/components/TipAlertAnimations/Default.tsx
@@ -73,10 +73,11 @@ const Default: React.FC<DefaultProps> = ({
 
       await new Promise((res) => setTimeout(res, 1000));
       setOut(true);
+      onAnimationEnd();
     };
 
     startPlayback();
-  }, [donate.amount, donate.commission, donate.id, donate.message, donate.nickname, out, sound?.url, sound?.volume, speech, withCommission]);
+  }, [donate.amount, donate.commission, donate.id, donate.message, donate.nickname, onAnimationEnd, out, sound?.url, sound?.volume, speech, withCommission]);
 
 
   const amount = withCommission


### PR DESCRIPTION
## Summary
- wrap GSAP timelines in `gsap.context` to simplify cleanup and prevent leaking animations
- invoke `onAnimationEnd` in default tip alert animation and include it in hook deps

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7f9183f508321a9c223c8cf196e3f